### PR TITLE
Pass 'all' as parameter to self.package call in version function

### DIFF
--- a/lib/models/repo.js
+++ b/lib/models/repo.js
@@ -88,7 +88,7 @@ Repo.prototype.package = function(version) {
 
 Repo.prototype.version = function(version) {
   return utils.co(function* (self) {
-    var pkg = yield self.package();
+    var pkg = yield self.package('all');
     if (pkg['dist-tags'][version]) {
       version = pkg['dist-tags'][version];
     }


### PR DESCRIPTION
Pass 'all' as the parameter to self.package call in version function. If you don't just the latest package.json gets returned, which does not have 'dist-tags' or versions causing error cannot get version of undefined.