### PR TITLE
remove deep-clone

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -2,7 +2,6 @@
 
 const url = require('url');
 const fetch = require('node-fetch');
-const utils = require('./utils.js');
 const config = require('./config.js');
 
 /** @typedef {import('./view.js')} View */
@@ -25,7 +24,7 @@ class List {
   constructor(name, view) {
     this.name = name;
     this.view = view;
-    this.config = utils.clone(config);
+    this.config = {...config};
     this.config.pathname += '/_list/' + this.view.name + '/' + this.name;
   }
 

--- a/lib/models/maintainer.js
+++ b/lib/models/maintainer.js
@@ -20,7 +20,7 @@ class Maintainer extends Base {
   constructor(name) {
     super();
     this.name = name;
-    this.config = utils.clone(config);
+    this.config = {...config};
   }
 
   /**

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fetch = require('node-fetch');
-const utils = require('./utils.js');
 const config = require('./config.js');
 
 /**
@@ -18,7 +17,7 @@ const config = require('./config.js');
 
 class Registry {
   constructor() {
-    this.config = utils.clone(config);
+    this.config = {...config};
   }
 
   /**

--- a/lib/view.js
+++ b/lib/view.js
@@ -21,7 +21,7 @@ const config = require('./config.js');
 class View {
   constructor(name) {
     this.name = name;
-    this.config = utils.clone(config);
+    this.config = {...config};
     this.config.pathname += '/_view/' + this.name;
   }
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "mocha": "^6.1.4"
   },
   "dependencies": {
-    "clone-deep": "^4.0.1",
     "download-stats": "^0.3.4",
     "JSONStream": "^1.3.5",
     "moment": "^2.24.0",


### PR DESCRIPTION
the only thing you used deep-clone for was to copy `config`
it dose not have any complext deep path so a `Object.assign({}, config)` would be enough, or even simpler: `{...config}`