### PR TITLE
Fix missing `fetch` function for electron bundles

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,6 +1,9 @@
 'use strict';
 
-const fetch = require('node-fetch');
+let fetch = require('node-fetch');
+if (fetch.default) {
+  fetch = fetch.default; 
+}
 const utils = require('./utils.js');
 const config = require('./config.js');
 


### PR DESCRIPTION
In electron setup, bundlers usually bundle for browser environments. In browser envs, bundles seem to pick up .mjs files first. .mjs fro node-fetch exports fetch as a default export. This fix allows bundling of npm-api for electron.